### PR TITLE
Change signature of ExecFnType to remove sync.WaitGroup

### DIFF
--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -53,14 +52,10 @@ func TestPipeline_StartStop(t *testing.T) {
 
 	processes := []*Process{proc1, proc2}
 	p, _ := NewPipeline("TestPipeline", processes)
-	wg := &sync.WaitGroup{}
-	wg.Add(1)
-	go p.Start(context.TODO(), wg)
-	wg.Wait()
 
-	wg.Add(1)
-	go p.Stop(context.TODO(), wg)
-	wg.Wait()
+	ctx := context.TODO()
+	p.Start(ctx)
+	p.Stop(ctx)
 }
 
 func TestPipeline_ProcessData1(t *testing.T) {
@@ -81,10 +76,9 @@ func TestPipeline_ProcessData1(t *testing.T) {
 		)
 	}
 	p, _ := NewPipeline("TestPipeline - All Jobs Succeed, 2 Processes", processes)
-	wg := &sync.WaitGroup{}
-	wg.Add(1)
-	go p.Start(context.TODO(), wg)
-	wg.Wait()
+
+	ctx := context.TODO()
+	p.Start(ctx)
 
 	for _, data := range datum {
 		p.ProcessData(data)
@@ -92,9 +86,7 @@ func TestPipeline_ProcessData1(t *testing.T) {
 
 	// TODO: Eliminate the need to wait for Process Data by adding a sync.WaitGroup
 	time.Sleep(10 * time.Second)
-	wg.Add(1)
-	go p.Stop(context.TODO(), wg)
-	wg.Wait()
+	p.Stop(ctx)
 
 	gotSuccessCount := atomic.LoadUint64(tp.successCount)
 	gotFailureCount := atomic.LoadUint64(tp.failureCount)
@@ -123,10 +115,9 @@ func TestPipeline_ProcessData2(t *testing.T) {
 		)
 	}
 	p, _ := NewPipeline("TestPipeline - All Jobs Succeed, 3 Processes", processes)
-	wg := &sync.WaitGroup{}
-	wg.Add(1)
-	go p.Start(context.TODO(), wg)
-	wg.Wait()
+
+	ctx := context.TODO()
+	p.Start(ctx)
 
 	for _, data := range datum {
 		p.ProcessData(data)
@@ -134,9 +125,7 @@ func TestPipeline_ProcessData2(t *testing.T) {
 
 	// TODO: Eliminate the need to wait for Process Data by adding a sync.WaitGroup
 	time.Sleep(10 * time.Second)
-	wg.Add(1)
-	go p.Stop(context.TODO(), wg)
-	wg.Wait()
+	p.Stop(ctx)
 
 	gotSuccessCount := atomic.LoadUint64(tp.successCount)
 	gotFailureCount := atomic.LoadUint64(tp.failureCount)
@@ -165,10 +154,9 @@ func TestPipeline_ProcessData3(t *testing.T) {
 		)
 	}
 	p, _ := NewPipeline("TestPipeline - All Jobs Succeed, 3 Processes, Expanding", processes)
-	wg := &sync.WaitGroup{}
-	wg.Add(1)
-	go p.Start(context.TODO(), wg)
-	wg.Wait()
+
+	ctx := context.TODO()
+	p.Start(ctx)
 
 	for _, data := range datum {
 		p.ProcessData(data)
@@ -176,9 +164,7 @@ func TestPipeline_ProcessData3(t *testing.T) {
 
 	// TODO: Eliminate the need to wait for Process Data by adding a sync.WaitGroup
 	time.Sleep(10 * time.Second)
-	wg.Add(1)
-	go p.Stop(context.TODO(), wg)
-	wg.Wait()
+	p.Stop(ctx)
 
 	gotSuccessCount := atomic.LoadUint64(tp.successCount)
 	gotFailureCount := atomic.LoadUint64(tp.failureCount)

--- a/process_test.go
+++ b/process_test.go
@@ -3,7 +3,6 @@ package piper
 import (
 	"context"
 	"strconv"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -173,14 +172,10 @@ func TestProcess_PushOnFailureFns(t *testing.T) {
 func TestProcess_StartStop(t *testing.T) {
 	te := testBatchExecEvensFailFn{}
 	p := NewProcess("TestProcess - Start/Stop", &te)
-	wg := &sync.WaitGroup{}
-	wg.Add(1)
-	go p.Start(context.TODO(), wg)
-	wg.Wait()
 
-	wg.Add(1)
-	go p.Stop(context.TODO(), wg)
-	wg.Wait()
+	ctx := context.TODO()
+	p.Start(ctx)
+	p.Stop(ctx)
 }
 
 func TestProcess_ProcessData1(t *testing.T) {
@@ -195,10 +190,9 @@ func TestProcess_ProcessData1(t *testing.T) {
 		ProcessWithMaxRetries(0),
 		ProcessWithBatchTimeout(500*time.Millisecond),
 	)
-	wg := &sync.WaitGroup{}
-	wg.Add(1)
-	go p.Start(context.TODO(), wg)
-	wg.Wait()
+
+	ctx := context.TODO()
+	p.Start(ctx)
 
 	for _, data := range datum {
 		p.ProcessData(data)
@@ -206,9 +200,7 @@ func TestProcess_ProcessData1(t *testing.T) {
 
 	// TODO: Eliminate the need to wait for Process Data by adding a sync.WaitGroup
 	time.Sleep(3 * time.Second)
-	wg.Add(1)
-	go p.Stop(context.TODO(), wg)
-	wg.Wait()
+	p.Stop(ctx)
 
 	gotSuccessCount := atomic.LoadUint64(tp.successCount)
 	gotFailureCount := atomic.LoadUint64(tp.failureCount)
@@ -232,10 +224,9 @@ func TestProcess_ProcessData2(t *testing.T) {
 		ProcessWithMaxRetries(retries),
 		ProcessWithBatchTimeout(500*time.Millisecond),
 	)
-	wg := &sync.WaitGroup{}
-	wg.Add(1)
-	go p.Start(context.TODO(), wg)
-	wg.Wait()
+
+	ctx := context.TODO()
+	p.Start(ctx)
 
 	for _, data := range datum {
 		p.ProcessData(data)
@@ -243,9 +234,7 @@ func TestProcess_ProcessData2(t *testing.T) {
 
 	// TODO: Eliminate the need to wait for Process Data by adding a sync.WaitGroup
 	time.Sleep(6 * time.Second)
-	wg.Add(1)
-	go p.Stop(context.TODO(), wg)
-	wg.Wait()
+	p.Stop(ctx)
 
 	gotSuccessCount := atomic.LoadUint64(tp.successCount)
 	if gotSuccessCount != 0 {

--- a/worker.go
+++ b/worker.go
@@ -2,7 +2,6 @@ package piper
 
 import (
 	"context"
-	"sync"
 )
 
 // status is a struct used to communicate the results of a worker's last batch job
@@ -35,9 +34,7 @@ func newWorker(fn BatchExecFn, statusCh chan *status) *worker {
 }
 
 // startFn defines the startup procedure for a worker
-func (w *worker) startFn(ctx context.Context, wg *sync.WaitGroup) {
-	defer wg.Done()
-
+func (w *worker) startFn(ctx context.Context) {
 	// Initialize channels
 	w.batchCh = make(chan *batch)
 	w.stopCh = make(chan struct{})
@@ -66,9 +63,7 @@ func (w *worker) startFn(ctx context.Context, wg *sync.WaitGroup) {
 }
 
 // stopFn defines the shutdown procedure for a worker
-func (w *worker) stopFn(ctx context.Context, wg *sync.WaitGroup) {
-	defer wg.Done()
-
+func (w *worker) stopFn(ctx context.Context) {
 	w.stopCh <- struct{}{}
 	close(w.stopCh)
 	close(w.batchCh)

--- a/worker_test.go
+++ b/worker_test.go
@@ -2,7 +2,6 @@ package piper
 
 import (
 	"context"
-	"sync"
 	"testing"
 )
 
@@ -30,16 +29,9 @@ func TestWorker_NewWorker(t *testing.T) {
 func TestWorker_StartDispatchStop(t *testing.T) {
 	td := newTestDispatcher()
 	w := newWorker(td.batchExecFn, td.statusCh)
-	wg := &sync.WaitGroup{}
-	wg.Add(1)
-	go w.exec.start(context.TODO(), wg)
-	wg.Wait()
 
-	defer func(wg *sync.WaitGroup) {
-		wg.Add(1)
-		go w.exec.stop(context.TODO(), wg)
-		wg.Wait()
-	}(wg)
+	ctx := context.TODO()
+	w.exec.start(ctx)
 
 	// Create some jobs and put it in a batch
 	numJobs := 10
@@ -52,4 +44,6 @@ func TestWorker_StartDispatchStop(t *testing.T) {
 
 	// Send the batch
 	status.address <- b
+
+	w.exec.stop(ctx)
 }


### PR DESCRIPTION
As it was being used, the start and stop functions were always being called synchronously, so the sync.WaitGroup was unnecessary.